### PR TITLE
Naming things: Use `retention_policy` (singular) as table name

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ and processing large amounts of data, it is crucial to manage data flows between
 hot and cold storage types better than using ad hoc solutions.
 
 Data retention policies can be flexibly configured by adding records to the
-`retention_policies` database table, which is also stored within CrateDB.
+retention policy database table, which is also stored within CrateDB.
 
 ### Background
 
@@ -49,10 +49,10 @@ resolution of data.
 
 ### Details
 
-> The `retention_policies` database table is also stored within CrateDB.
+> The retention policy database table is also stored within CrateDB.
 
 By default, the `ext` schema is used for that, so the effective full-qualified database
-table name is `"ext"."retention_policies"`. It is configurable by using the `--schema`
+table name is `"ext"."retention_policy"`. It is configurable by using the `--schema`
 command-line option, or the `CRATEDB_EXT_SCHEMA` environment variable.
 
 
@@ -67,7 +67,7 @@ A basic retention policy algorithm that drops records from expired partitions.
 
 ```sql
 -- A policy using the DELETE strategy.
-INSERT INTO retention_policies
+INSERT INTO "ext"."retention_policy"
   (table_schema, table_name, partition_column, retention_period, strategy)
 VALUES
   ('doc', 'raw_metrics', 'ts_day', 1, 'delete');
@@ -90,7 +90,8 @@ large amounts of storage space.
 
 ```sql
 -- A policy using the REALLOCATE strategy.
-INSERT INTO retention_policies VALUES
+INSERT INTO "ext"."retention_policy"
+VALUES
   ('doc', 'raw_metrics', 'ts_day', 60, 'storage', 'cold', NULL, 'reallocate');
 ```
 
@@ -107,7 +108,7 @@ where data in form of snapshots can be exported to, and imported from.
 
 ```sql
 -- A policy using the SNAPSHOT strategy.
-INSERT INTO retention_policies
+INSERT INTO "ext"."retention_policy"
   (table_schema, table_name, partition_column, retention_period, target_repository_name, strategy)
 VALUES
   ('doc', 'sensor_readings', 'time_month', 365, 'export_cold', 'snapshot');
@@ -135,9 +136,10 @@ Define a few retention policy rules using SQL.
 ```shell
 # A policy using the DELETE strategy.
 docker run --rm -i --network=host crate crash <<SQL
-    INSERT INTO retention_policies (
-      table_schema, table_name, partition_column, retention_period, strategy)
-    VALUES ('doc', 'raw_metrics', 'ts_day', 1, 'delete');
+    INSERT INTO "ext"."retention_policy"
+      (table_schema, table_name, partition_column, retention_period, strategy)
+    VALUES
+      ('doc', 'raw_metrics', 'ts_day', 1, 'delete');
 SQL
 ```
 

--- a/cratedb_retention/cli.py
+++ b/cratedb_retention/cli.py
@@ -21,7 +21,7 @@ def help_setup():
     Synopsis
     ========
 
-    # Materialize `retention_policies` database schema.
+    # Set up the retention policy database table schema.
     cratedb-retention setup "crate://localhost/"
 
     """  # noqa: E501

--- a/cratedb_retention/model.py
+++ b/cratedb_retention/model.py
@@ -51,9 +51,9 @@ class Settings:
     # Retention cutoff timestamp.
     cutoff_day: t.Optional[str] = None
 
-    # Where the `retention_policies` is stored.
+    # Where the retention policy table is stored.
     policy_table: TableAddress = dataclasses.field(
-        default_factory=lambda: TableAddress(schema="ext", table="retention_policies")
+        default_factory=lambda: TableAddress(schema="ext", table="retention_policy")
     )
 
     def to_dict(self):

--- a/cratedb_retention/setup/schema.py
+++ b/cratedb_retention/setup/schema.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 def setup_schema(settings: Settings):
     """
-    Set up `retention_policies` table schema.
+    Set up the retention policy table schema.
     """
 
     logger.info(

--- a/cratedb_retention/setup/schema.sql
+++ b/cratedb_retention/setup/schema.sql
@@ -1,4 +1,4 @@
--- Set up `retention_policies` table schema.
+-- Set up the retention policy database table schema.
 
 CREATE TABLE IF NOT EXISTS {policy_table.fullname} (
    "table_schema" TEXT,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@ TESTDRIVE_EXT_SCHEMA = "testdrive-ext"
 TESTDRIVE_DATA_SCHEMA = "testdrive-data"
 
 RESET_TABLES = [
-    f'"{TESTDRIVE_EXT_SCHEMA}"."retention_policies"',
+    f'"{TESTDRIVE_EXT_SCHEMA}"."retention_policy"',
     f'"{TESTDRIVE_DATA_SCHEMA}"."raw_metrics"',
     f'"{TESTDRIVE_DATA_SCHEMA}"."sensor_readings"',
     f'"{TESTDRIVE_DATA_SCHEMA}"."testdrive"',
@@ -69,7 +69,7 @@ def cratedb():
 @pytest.fixture(scope="function")
 def provision_database(cratedb):
     """
-    Populate `retention_policies` table, and data tables.
+    Populate the retention policy table, and the data tables.
     """
     cratedb.reset()
 


### PR DESCRIPTION
It is advised to use singular table names for entities these days.

> For new projects or where you can easily change the name of entities
> then I would say you must use singular names, for older projects
> you'll need to be a bit more pragmatic!
>
> --The.AgileSQL.Club
>
> -- https://www.dbdebunk.com/2019/05/naming-relations-singular-or-plural.html

> The arguments for plural are straightforward: It reads well in the `FROM` clause.
> The arguments for singular are more subtle: It reads well everywhere else in the SQL query.
>
> -- https://www.teamten.com/lawrence/programming/use-singular-nouns-for-database-table-names.html

> **How to name tables?**
> - Use lower letters when naming database objects. For separating words in the database object name, use underscore.
> - Use singular for table names (`user`, `role`), and not plural (`users`, `roles`). The plural could lead to some weird table names later (instead of `user_has_role`, you would have `users_have_roles`, etc.).
>
> -- https://www.sqlshack.com/learn-sql-naming-conventions/
