### PR TITLE
Add `RetentionPolicy` entity, and generalize SQL templates

### DIFF
--- a/cratedb_retention/setup/schema.py
+++ b/cratedb_retention/setup/schema.py
@@ -23,7 +23,7 @@ def setup_schema(settings: Settings):
     sql = read_text("cratedb_retention.setup", "schema.sql")
 
     tplvars = settings.to_dict()
-    sql = sql.format(**tplvars)
+    sql = sql.format_map(tplvars)
 
     # Materialize table schema.
     run_sql(settings.dburi, sql)

--- a/cratedb_retention/strategy/delete.py
+++ b/cratedb_retention/strategy/delete.py
@@ -13,39 +13,27 @@ See the file setup/schema.sql in this repository.
 import dataclasses
 import logging
 
-from cratedb_retention.model import GenericAction, GenericRetention
+from cratedb_retention.model import GenericRetention, RetentionPolicy
 
 logger = logging.getLogger(__name__)
 
 
 @dataclasses.dataclass
-class DeleteAction(GenericAction):
+class DeleteAction(RetentionPolicy):
     """
     Manage metadata representing a data retention operation on a single table.
     """
-
-    table_fqn: str
-    column: str
-    value: int
 
     def to_sql(self):
         """
         Render as SQL statement.
         """
         # FIXME: S608 Possible SQL injection vector through string-based query construction
-        sql = f"""DELETE FROM {self.table_fqn} WHERE {self.column} = {self.value};"""  # noqa: S608
+        sql = f"""
+            DELETE FROM {self.table_fullname}
+            WHERE {self.partition_column} = {self.partition_value};
+        """  # noqa: S608
         return sql
-
-    @staticmethod
-    def record_mapper(record):
-        """
-        Map database record to instance attributes.
-        """
-        return {
-            "table_fqn": record[0],
-            "column": record[1],
-            "value": record[2],
-        }
 
 
 @dataclasses.dataclass

--- a/cratedb_retention/strategy/delete_tasks.sql
+++ b/cratedb_retention/strategy/delete_tasks.sql
@@ -1,11 +1,5 @@
 -- Copyright (c) 2021-2023, Crate.io Inc.
 -- Distributed under the terms of the AGPLv3 license, see LICENSE.
 
-SELECT QUOTE_IDENT(p.table_schema) || '.' || QUOTE_IDENT(p.table_name),
-       QUOTE_IDENT(r.partition_column),
-       TRY_CAST(p.values[r.partition_column] AS BIGINT)
-FROM information_schema.table_partitions p
-JOIN {policy_table.fullname} r ON p.table_schema = r.table_schema
-  AND p.table_name = r.table_name
-  AND p.values[r.partition_column] < '{cutoff_day}'::TIMESTAMP - (r.retention_period || ' days')::INTERVAL
+{policy_dql}
 WHERE r.strategy = 'delete';

--- a/cratedb_retention/strategy/policy.sql
+++ b/cratedb_retention/strategy/policy.sql
@@ -1,0 +1,23 @@
+-- Copyright (c) 2021-2023, Crate.io Inc.
+-- Distributed under the terms of the AGPLv3 license, see LICENSE.
+
+-- SQL DQL clause for selecting records from the retention policy database table,
+-- used for all strategy implementations. It can be interpolated into other SQL
+-- templates by using the `policy_dql` template variable.
+
+-- The retention policy database table is called `"ext"."retention_policy"` by default.
+
+SELECT strategy,
+       p.table_schema,
+       p.table_name,
+       QUOTE_IDENT(p.table_schema) || '.' || QUOTE_IDENT(p.table_name),
+       QUOTE_IDENT(r.partition_column),
+       TRY_CAST(p.values[r.partition_column] AS BIGINT),
+       reallocation_attribute_name,
+       reallocation_attribute_value,
+       target_repository_name
+FROM "information_schema"."table_partitions" p
+JOIN {policy_table.fullname} r ON
+  p.table_schema = r.table_schema AND
+  p.table_name = r.table_name AND
+  p.values[r.partition_column] < '{cutoff_day}'::TIMESTAMP - (r.retention_period || ' days')::INTERVAL

--- a/cratedb_retention/strategy/reallocate_tasks.sql
+++ b/cratedb_retention/strategy/reallocate_tasks.sql
@@ -9,17 +9,7 @@ WITH partition_allocations AS (
   FROM sys.shards s
   JOIN sys.nodes n ON s.node['id'] = n.id
 )
-SELECT QUOTE_IDENT(p.table_schema),
-       QUOTE_IDENT(p.table_name),
-       QUOTE_IDENT(p.table_schema) || '.' || QUOTE_IDENT(p.table_name),
-       QUOTE_IDENT(r.partition_column),
-       TRY_CAST(p.values[r.partition_column] AS BIGINT),
-       reallocation_attribute_name,
-       reallocation_attribute_value
-FROM information_schema.table_partitions p
-JOIN {policy_table.fullname} r ON p.table_schema = r.table_schema
-  AND p.table_name = r.table_name
-  AND p.values[r.partition_column] < '{cutoff_day}'::TIMESTAMP - (r.retention_period || ' days')::INTERVAL
+{policy_dql}
 JOIN partition_allocations a ON a.table_schema = p.table_schema
   AND a.table_name = p.table_name
   AND p.partition_ident = a.partition_ident

--- a/cratedb_retention/strategy/snapshot_tasks.sql
+++ b/cratedb_retention/strategy/snapshot_tasks.sql
@@ -1,15 +1,5 @@
 -- Copyright (c) 2021-2023, Crate.io Inc.
 -- Distributed under the terms of the AGPLv3 license, see LICENSE.
 
--- intentionally not adding QUOTE_IDENT to the first two columns, as they are used in an already quoted string later on
-SELECT p.table_schema,
-       p.table_name,
-       QUOTE_IDENT(p.table_schema) || '.' || QUOTE_IDENT(p.table_name),
-       QUOTE_IDENT(r.partition_column),
-       TRY_CAST(p.values[r.partition_column] AS BIGINT),
-       target_repository_name
-FROM information_schema.table_partitions p
-JOIN {policy_table.fullname} r ON p.table_schema = r.table_schema
-  AND p.table_name = r.table_name
-  AND p.values[r.partition_column] < '{cutoff_day}'::TIMESTAMP - (r.retention_period || ' days')::INTERVAL
+{policy_dql}
 WHERE r.strategy = 'snapshot';


### PR DESCRIPTION
### Introduction

The SQL templates for the different data retention strategies all use the same SQL DQL clause for accessing columns of the retention policy table. Their corresponding Python support code deviates only slightly in the number and order of the decoded columns.

### Improvement

This patch generalizes that, by adding a dedicated and generic `RetentionPolicy` object, where corresponding database records are unmarshalled to. It tremendously improves maintenance, trimming down the amount of code needed to implement specific strategies significantly, saving a few lines of boilerplate for each.
