### PR TITLE
Expand usability: Use as a library, and naming things

### DIFF
--- a/cratedb_retention/cli.py
+++ b/cratedb_retention/cli.py
@@ -6,8 +6,8 @@ import typing as t
 
 import click
 
-from cratedb_retention.core import Engine
-from cratedb_retention.model import DatabaseAddress, RetentionStrategy, Settings
+from cratedb_retention.core import RetentionJob
+from cratedb_retention.model import DatabaseAddress, JobSettings, RetentionStrategy
 from cratedb_retention.setup.schema import setup_schema
 from cratedb_retention.util.cli import boot_click, docstring_format_verbatim
 
@@ -72,9 +72,9 @@ def setup(ctx: click.Context, dburi: str, schema: t.Optional[str]):
         logger.error("Unable to operate without database")
         sys.exit(1)
 
-    # Create `Settings` instance.
+    # Create `JobSettings` instance.
     # It is the single source of truth about configuration and runtime settings.
-    settings = Settings(database=DatabaseAddress.from_string(dburi))
+    settings = JobSettings(database=DatabaseAddress.from_string(dburi))
     if schema is not None:
         settings.policy_table.schema = schema
 
@@ -102,9 +102,9 @@ def run(ctx: click.Context, dburi: str, cutoff_day: str, strategy: str, schema: 
         logger.error(f"Unknown strategy. Select one of {strategy_choices}")
         sys.exit(1)
 
-    # Create `Settings` instance.
+    # Create `JobSettings` instance.
     # It is the single source of truth about configuration and runtime settings.
-    settings = Settings(
+    settings = JobSettings(
         database=DatabaseAddress.from_string(dburi),
         strategy=RetentionStrategy(strategy),
         cutoff_day=cutoff_day,
@@ -112,6 +112,6 @@ def run(ctx: click.Context, dburi: str, cutoff_day: str, strategy: str, schema: 
     if schema is not None:
         settings.policy_table.schema = schema
 
-    # Invoke the engine.
-    engine = Engine(settings=settings)
-    engine.start()
+    # Invoke the data retention job.
+    job = RetentionJob(settings=settings)
+    job.start()

--- a/cratedb_retention/core.py
+++ b/cratedb_retention/core.py
@@ -3,7 +3,7 @@
 import logging
 import typing as t
 
-from cratedb_retention.model import GenericRetention, RetentionStrategy, Settings
+from cratedb_retention.model import GenericRetention, JobSettings, RetentionStrategy
 from cratedb_retention.strategy.delete import DeleteRetention
 from cratedb_retention.strategy.reallocate import ReallocateRetention
 from cratedb_retention.strategy.snapshot import SnapshotRetention
@@ -11,15 +11,16 @@ from cratedb_retention.strategy.snapshot import SnapshotRetention
 logger = logging.getLogger(__name__)
 
 
-class Engine:
+class RetentionJob:
     """
-    Implementation of the retention and expiration management subsystem for CrateDB.
+    The retention job implementation evaluates its configuration and runtime settings,
+    and dispatches to corresponding retention strategy implementations.
 
-    This is the main application, effectively evaluating configuration settings,
-    and dispatching to corresponding retention strategy implementations.
+    This is effectively the main application, implementing a retention and expiration
+    management subsystem for CrateDB.
     """
 
-    def __init__(self, settings: Settings):
+    def __init__(self, settings: JobSettings):
         self.settings = settings
 
     def start(self):

--- a/cratedb_retention/model.py
+++ b/cratedb_retention/model.py
@@ -109,13 +109,15 @@ class TableAddress:
 
 
 @dataclasses.dataclass
-class Settings:
+class JobSettings:
     """
     Bundle all configuration and runtime settings.
     """
 
     # Database connection URI.
-    database: DatabaseAddress = dataclasses.field(default_factory=lambda: DatabaseAddress(uri="crate://localhost/"))
+    database: DatabaseAddress = dataclasses.field(
+        default_factory=lambda: DatabaseAddress.from_string("crate://localhost/")
+    )
 
     # Retention strategy.
     strategy: t.Optional[RetentionStrategy] = None
@@ -141,7 +143,7 @@ class GenericRetention:
     """
 
     # Runtime context settings.
-    settings: Settings
+    settings: JobSettings
 
     # File name of SQL statement to load retention policies.
     _tasks_sql: str = dataclasses.field(init=False)

--- a/cratedb_retention/setup/schema.py
+++ b/cratedb_retention/setup/schema.py
@@ -3,13 +3,13 @@
 import logging
 from importlib.resources import read_text
 
-from cratedb_retention.model import Settings
+from cratedb_retention.model import JobSettings
 from cratedb_retention.util.database import run_sql
 
 logger = logging.getLogger(__name__)
 
 
-def setup_schema(settings: Settings):
+def setup_schema(settings: JobSettings):
     """
     Set up the retention policy table schema.
     """

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -1,0 +1,90 @@
+# Copyright (c) 2023, Crate.io Inc.
+# Distributed under the terms of the AGPLv3 license, see LICENSE.
+"""
+Example program demonstrating how to set up a data retention policy,
+and invoke it.
+
+It initializes the data retention and expiry subsystem, and creates
+a data retention policy. After that, it invokes the corresponding
+data retention job.
+
+The program obtains a single positional argument from the command line,
+the database URI, in SQLAlchemy-compatible string format.
+"""
+import sys
+
+from sqlalchemy.exc import ProgrammingError
+
+from cratedb_retention.core import RetentionJob
+from cratedb_retention.model import DatabaseAddress, JobSettings, RetentionStrategy
+from cratedb_retention.setup.schema import setup_schema
+from cratedb_retention.util.common import setup_logging
+from cratedb_retention.util.database import run_sql
+
+
+def setup_retention(dburi: str):
+    """
+    How to initialize the subsystem, and create a data retention policy.
+    """
+    # Create `JobSettings` instance.
+    # It is the single source of truth about configuration and runtime settings.
+    settings = JobSettings(
+        database=DatabaseAddress.from_string(dburi),
+    )
+    setup_schema(settings=settings)
+
+    # TODO: All values are currently hardcoded.
+    sql = """
+    -- A policy using the DELETE strategy.
+    INSERT INTO "ext"."retention_policy"
+      (table_schema, table_name, partition_column, retention_period, strategy)
+    VALUES
+      ('doc', 'raw_metrics', 'ts_day', 1, 'delete');
+    """
+    try:
+        run_sql(dburi, sql)
+    except ProgrammingError as ex:
+        if "DuplicateKeyException" not in str(ex):
+            raise
+
+
+def run_retention(dburi: str, strategy: str, cutoff_day: str):
+    """
+    How to invoke a data retention job.
+    """
+    # Create `JobSettings` instance.
+    # It is the single source of truth about configuration and runtime settings.
+    settings = JobSettings(
+        database=DatabaseAddress.from_string(dburi),
+        strategy=RetentionStrategy(strategy.upper()),
+        cutoff_day=cutoff_day,
+    )
+
+    # Invoke the data retention job.
+    job = RetentionJob(settings=settings)
+    job.start()
+
+
+def main(dburi: str):
+    """
+    Set up a data retention policy, and invoke the corresponding job.
+    """
+    setup_retention(dburi)
+    run_retention(
+        dburi=dburi,
+        strategy="delete",
+        cutoff_day="2023-06-27",
+    )
+
+
+if __name__ == "__main__":
+    """
+    The program obtains a single positional argument from the command line,
+    the database URI, in SQLAlchemy-compatible string format.
+    """
+    setup_logging()
+    try:
+        dburi = sys.argv[1]
+    except IndexError:
+        dburi = "crate://localhost/"
+    main(dburi)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,6 +148,7 @@ log_level = "DEBUG"
 log_cli_level = "DEBUG"
 log_format = "%(asctime)-15s [%(name)-24s] %(levelname)-8s: %(message)s"
 testpaths = [
+  "examples",
   "cratedb_retention",
   "tests",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@
 import pytest
 import sqlalchemy as sa
 
-from cratedb_retention.model import DatabaseAddress, Settings
+from cratedb_retention.model import DatabaseAddress, JobSettings
 from cratedb_retention.setup.schema import setup_schema
 from cratedb_retention.util.common import setup_logging
 from cratedb_retention.util.database import run_sql
@@ -75,7 +75,7 @@ def provision_database(cratedb):
 
     database_url = cratedb.get_connection_url()
 
-    settings = Settings(database=DatabaseAddress.from_string(database_url))
+    settings = JobSettings(database=DatabaseAddress.from_string(database_url))
     settings.policy_table.schema = TESTDRIVE_EXT_SCHEMA
     setup_schema(settings=settings)
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,0 +1,11 @@
+# Copyright (c) 2023, Crate.io Inc.
+# Distributed under the terms of the AGPLv3 license, see LICENSE.
+
+
+def test_example_basic(cratedb):
+    """
+    Verify that the program `examples/basic.py` works.
+    """
+    from examples.basic import main
+
+    main(dburi=cratedb.get_connection_url())


### PR DESCRIPTION
### About

This patch brings in documentation how to use the toolkit as a library. Along the lines, it takes the chance to adjust the naming of a few components a bit: `Engine` -> `RetentionJob`, `Settings` -> `JobSettings`.
