### PR TITLE
SQL schema: Move `strategy` column to front of retention policy table

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,9 +256,9 @@ Add a retention policy rule using SQL.
 # A policy using the DELETE strategy.
 crash --hosts "${CRATEDB_HOST}" <<SQL
     INSERT INTO "ext"."retention_policy"
-      (table_schema, table_name, partition_column, retention_period, strategy)
+      (strategy, table_schema, table_name, partition_column, retention_period)
     VALUES
-      ('doc', 'raw_metrics', 'ts_day', 1, 'delete');
+      ('delete', 'doc', 'raw_metrics', 'ts_day', 1);
 SQL
 ```
 
@@ -307,9 +307,9 @@ Add a retention policy rule using SQL.
 docker run --rm -i --network=host "${OCI_IMAGE}" \
 crash --hosts "${CRATEDB_HOST}" <<SQL
     INSERT INTO "ext"."retention_policy"
-      (table_schema, table_name, partition_column, retention_period, strategy)
+      (strategy, table_schema, table_name, partition_column, retention_period)
     VALUES
-      ('doc', 'raw_metrics', 'ts_day', 1, 'delete');
+      ('delete', 'doc', 'raw_metrics', 'ts_day', 1);
 SQL
 ```
 
@@ -346,9 +346,9 @@ setup_schema(settings=settings)
 sql = """
 -- A policy using the DELETE strategy.
 INSERT INTO "ext"."retention_policy"
-  (table_schema, table_name, partition_column, retention_period, strategy)
+  (strategy, table_schema, table_name, partition_column, retention_period)
 VALUES
-  ('doc', 'raw_metrics', 'ts_day', 1, 'delete');
+  ('delete', 'doc', 'raw_metrics', 'ts_day', 1);
 """
 run_sql(DBURI, sql)
 

--- a/cratedb_retention/setup/schema.sql
+++ b/cratedb_retention/setup/schema.sql
@@ -1,6 +1,9 @@
 -- Set up the retention policy database table schema.
 CREATE TABLE IF NOT EXISTS {policy_table.fullname} (
 
+    -- Strategy to apply for data retention.
+    "strategy" TEXT NOT NULL,
+
     -- Source: The database table operated upon.
     "table_schema" TEXT,                        -- The source table schema.
     "table_name" TEXT,                          -- The source table name.
@@ -22,9 +25,6 @@ CREATE TABLE IF NOT EXISTS {policy_table.fullname} (
     -- Targeting a repository.
     "target_repository_name" TEXT,              -- The name of a repository created with `CREATE REPOSITORY ...`.
 
-    -- Strategy to apply for data retention.
-    "strategy" TEXT NOT NULL,
-
-    PRIMARY KEY ("table_schema", "table_name", "strategy")
+    PRIMARY KEY ("strategy", "table_schema", "table_name")
 )
 CLUSTERED INTO 1 SHARDS;

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -37,9 +37,9 @@ def setup_retention(dburi: str):
     sql = """
     -- A policy using the DELETE strategy.
     INSERT INTO "ext"."retention_policy"
-      (table_schema, table_name, partition_column, retention_period, strategy)
+      (strategy, table_schema, table_name, partition_column, retention_period)
     VALUES
-      ('doc', 'raw_metrics', 'ts_day', 1, 'delete');
+      ('delete', 'doc', 'raw_metrics', 'ts_day', 1);
     """
     try:
         run_sql(dburi, sql)


### PR DESCRIPTION
### About

By moving the `strategy` column to the front of the retention policy table, a retention policy record almost reads like natural language.

```sql
-- A policy using the REALLOCATE strategy.
INSERT INTO "ext"."retention_policy"
  (strategy, table_schema, table_name, partition_column, retention_period, reallocation_attribute_name, reallocation_attribute_value)
VALUES
  ('reallocate', 'doc', 'raw_metrics', 'ts_day', 60, 'storage', 'cold');
```

### Question

@hammerhead: Would that statement be correct, to describe this retention policy in human language? Can you correct it, if I got it wrong?

> **Reallocate** data from the `"doc"."raw_metrics"` table to machines running nodes tagged with `node.attr.storage=cold`, on partitions defined by column `ts_day`, when it is older than **60** days.

See also https://github.com/crate-workbench/cratedb-retention/pull/14#discussion_r1246068805.
