### PR TITLE
SQL schema: Also return original value of `retention_period`

### DIFF
--- a/cratedb_retention/model.py
+++ b/cratedb_retention/model.py
@@ -37,6 +37,7 @@ class RetentionPolicy:
     table_fullname: str
     partition_column: str
     partition_value: str
+    retention_period: int
     reallocation_attribute_name: str
     reallocation_attribute_value: str
     target_repository_name: str

--- a/cratedb_retention/strategy/policy.sql
+++ b/cratedb_retention/strategy/policy.sql
@@ -13,6 +13,7 @@ SELECT strategy,
        QUOTE_IDENT(p.table_schema) || '.' || QUOTE_IDENT(p.table_name),
        QUOTE_IDENT(r.partition_column),
        TRY_CAST(p.values[r.partition_column] AS BIGINT),
+       r.retention_period,
        reallocation_attribute_name,
        reallocation_attribute_value,
        target_repository_name


### PR DESCRIPTION
### About

For the sake of completeness, also return the value of the `retention_period` column, when loading retention policy records from the corresponding database table.