### PR TITLE
Add "dry run" mode, to pretend invoking SQL statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,10 +300,17 @@ Note that, currently, the Python driver and the crash database
 shell need to obtain slightly different parameters. 
 ```
 
-By using the `--verbose` option, directly after the main command, you can
-inspect the SQL statements issued to the database.
+By using the `--verbose` option, directly after the main command, before the
+subcommand, you can inspect the SQL statements issued to the database.
 ```shell
 cratedb-retention --verbose setup "${CRATEDB_URI}"
+```
+
+By using the `--dry-run` option, after the subcommand, the program will not
+issue altering or modifying SQL statements to the database. You can use it
+to learn about which actions would be performed.
+```shell
+cratedb-retention setup --dry-run "${CRATEDB_URI}"
 ```
 
 The `DBURI` command-line argument can be omitted when defining the `CRATEDB_URI`
@@ -351,6 +358,11 @@ cratedb-retention create-policy --strategy=delete \
 Invoke the data retention job, using a specific cut-off date.
 ```shell
 cratedb-retention run --cutoff-day=2023-06-27 --strategy=delete "${CRATEDB_URI}"
+```
+
+Simulate the data retention job, display SQL statements only.
+```shell
+cratedb-retention run --dry-run --cutoff-day=2023-06-27 --strategy=delete "${CRATEDB_URI}"
 ```
 
 #### Podman or Docker

--- a/cratedb_retention/core.py
+++ b/cratedb_retention/core.py
@@ -58,6 +58,9 @@ class RetentionJob:
             # Run a sequence of SQL statements for this task.
             # Stop the sequence when a step fails.
             for sql in sql_bunch:
+                if self.settings.dry_run:
+                    logger.info(f"Pretending to execute SQL statement:\n{sql}")
+                    continue
                 try:
                     run_sql(dburi=self.settings.database.dburi, sql=sql)
                 except Exception:
@@ -91,6 +94,7 @@ class RetentionJob:
                 logger.warning(f"Data table not found: {policy.table_fullname}")
                 continue
 
+            # Render SQL statement to gather tasks.
             sql_renderer = TaskSqlRenderer(settings=self.settings, store=self.store, policy=policy)
             selectable = sql_renderer.render()
             results = self.store.query(selectable)

--- a/cratedb_retention/model.py
+++ b/cratedb_retention/model.py
@@ -232,6 +232,9 @@ class JobSettings:
     # Where the retention policy table is stored.
     policy_table: TableAddress = dataclasses.field(default_factory=default_table_address)
 
+    # Only pretend to invoke retention tasks.
+    dry_run: t.Optional[bool] = False
+
     def to_dict(self):
         data = dataclasses.asdict(self)
         data["policy_table"] = self.policy_table

--- a/cratedb_retention/setup/schema.py
+++ b/cratedb_retention/setup/schema.py
@@ -12,6 +12,8 @@ logger = logging.getLogger(__name__)
 def setup_schema(settings: JobSettings):
     """
     Set up the retention policy table schema.
+
+    TODO: Refactor to `store` module.
     """
 
     logger.info(
@@ -24,6 +26,10 @@ def setup_schema(settings: JobSettings):
 
     tplvars = settings.to_dict()
     sql = sql.format_map(tplvars)
+
+    if settings.dry_run:
+        logger.info(f"Pretending to execute SQL statement:\n{sql}")
+        return
 
     # Materialize table schema.
     run_sql(settings.database.dburi, sql)


### PR DESCRIPTION
## About

- By using the `--dry-run` command-line option, the program will only pretent to invoke data retention SQL statements.
- Instead, it will send them to the logger for inspection and education purposes.
- Currently, this works on `setup` and `run` subcommands.
