### PR TITLE
Chore: This and that

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,8 @@ jobs:
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}
+      # Do not tear down Testcontainers
+      TC_KEEPALIVE: true
 
     name: Python ${{ matrix.python-version }} on OS ${{ matrix.os }}
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -206,7 +206,7 @@ extend-exclude = [
 ]
 
 [tool.ruff.per-file-ignores]
-"tests/*" = ["S101", "T201"]  # Allow use of `assert`, and `print`.
+"tests/*" = ["S101"]  # Allow use of `assert`, and `print`.
 "examples/*" = ["T201"]  # Allow `print`
 "cratedb_retention/cli.py" = ["T201"]  # Allow `print`
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -135,9 +135,11 @@ def raw_metrics(cratedb, settings, store):
     Populate the `raw_metrics` table.
     """
 
+    tablename_full = f'"{TESTDRIVE_DATA_SCHEMA}"."raw_metrics"'
+
     database_url = cratedb.get_connection_url()
     ddl = f"""
-        CREATE TABLE "{TESTDRIVE_DATA_SCHEMA}"."raw_metrics" (
+        CREATE TABLE {tablename_full} (
            "variable" TEXT,
            "timestamp" TIMESTAMP WITH TIME ZONE,
            "ts_day" TIMESTAMP GENERATED ALWAYS AS date_trunc('day', "timestamp"),
@@ -151,7 +153,7 @@ def raw_metrics(cratedb, settings, store):
     """
 
     dml = f"""
-        INSERT INTO "{TESTDRIVE_DATA_SCHEMA}"."raw_metrics"
+        INSERT INTO {tablename_full}
             (variable, timestamp, value, quality)
         SELECT
             'temperature' AS variable,
@@ -163,7 +165,9 @@ def raw_metrics(cratedb, settings, store):
 
     run_sql(database_url, ddl)
     run_sql(database_url, dml)
-    run_sql(database_url, f'REFRESH TABLE "{TESTDRIVE_DATA_SCHEMA}"."raw_metrics";')
+    run_sql(database_url, f"REFRESH TABLE {tablename_full};")
+
+    return tablename_full
 
 
 @pytest.fixture(scope="function")
@@ -172,9 +176,11 @@ def sensor_readings(cratedb, settings, store):
     Populate the `sensor_readings` table.
     """
 
+    tablename_full = f'"{TESTDRIVE_DATA_SCHEMA}"."sensor_readings"'
+
     database_url = cratedb.get_connection_url()
     ddl = f"""
-        CREATE TABLE "{TESTDRIVE_DATA_SCHEMA}"."sensor_readings" (
+        CREATE TABLE {tablename_full} (
            time TIMESTAMP WITH TIME ZONE NOT NULL,
            time_month TIMESTAMP WITH TIME ZONE GENERATED ALWAYS AS DATE_TRUNC('month', "time"),
            sensor_id TEXT NOT NULL,
@@ -186,7 +192,7 @@ def sensor_readings(cratedb, settings, store):
     """
 
     dml = f"""
-        INSERT INTO "{TESTDRIVE_DATA_SCHEMA}"."sensor_readings"
+        INSERT INTO {tablename_full}
             (time, sensor_id, battery_level, battery_status, battery_temperature)
         SELECT
             generate_series AS time,
@@ -203,7 +209,9 @@ def sensor_readings(cratedb, settings, store):
 
     run_sql(database_url, ddl)
     run_sql(database_url, dml)
-    run_sql(database_url, f'REFRESH TABLE "{TESTDRIVE_DATA_SCHEMA}"."sensor_readings";')
+    run_sql(database_url, f"REFRESH TABLE {tablename_full};")
+
+    return tablename_full
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -146,6 +146,9 @@ def test_run_delete_basic(store, database, raw_metrics, policies):
     database_url = store.database.dburi
     runner = CliRunner()
 
+    # Check number of records in database.
+    assert database.count_records(raw_metrics) == 6
+
     # Invoke data retention through CLI interface.
     result = runner.invoke(
         cli,
@@ -154,8 +157,8 @@ def test_run_delete_basic(store, database, raw_metrics, policies):
     )
     assert result.exit_code == 0
 
-    # Verify that records have been deleted.
-    assert database.count_records(f'"{TESTDRIVE_DATA_SCHEMA}"."raw_metrics"') == 0
+    # Check number of records in database.
+    assert database.count_records(raw_metrics) == 0
 
 
 def test_run_delete_dryrun(caplog, store, database, raw_metrics, policies):
@@ -166,6 +169,9 @@ def test_run_delete_dryrun(caplog, store, database, raw_metrics, policies):
     database_url = store.database.dburi
     runner = CliRunner()
 
+    # Check number of records in database.
+    assert database.count_records(raw_metrics) == 6
+
     # Invoke data retention through CLI interface.
     result = runner.invoke(
         cli,
@@ -173,11 +179,10 @@ def test_run_delete_dryrun(caplog, store, database, raw_metrics, policies):
         catch_exceptions=False,
     )
     assert result.exit_code == 0
-
-    # Verify that records have been deleted.
-    assert database.count_records(f'"{TESTDRIVE_DATA_SCHEMA}"."raw_metrics"') == 6
-
     assert "Pretending to execute SQL statement" in caplog.text
+
+    # Check number of records in database.
+    assert database.count_records(raw_metrics) == 6
 
 
 def test_run_delete_with_tags_match(store, database, sensor_readings, policies):
@@ -187,6 +192,9 @@ def test_run_delete_with_tags_match(store, database, sensor_readings, policies):
 
     database_url = store.database.dburi
     runner = CliRunner()
+
+    # Check number of records in database.
+    assert database.count_records(sensor_readings) == 9
 
     # Invoke data retention through CLI interface.
     result = runner.invoke(
@@ -208,6 +216,9 @@ def test_run_delete_with_tags_unknown(caplog, store, database, sensor_readings, 
     database_url = store.database.dburi
     runner = CliRunner()
 
+    # Check number of records in database.
+    assert database.count_records(sensor_readings) == 9
+
     # Invoke data retention through CLI interface.
     result = runner.invoke(
         cli,
@@ -216,10 +227,11 @@ def test_run_delete_with_tags_unknown(caplog, store, database, sensor_readings, 
     )
     assert result.exit_code == 0
 
-    # Verify that records have not been deleted, because the tags did not match.
-    assert database.count_records(f'"{TESTDRIVE_DATA_SCHEMA}"."sensor_readings"') == 9
-
     assert "No retention policies found with tags: ['foo', 'unknown']" in caplog.messages
+
+    # Check number of records in database.
+    # Records have not been deleted, because the tags did not match.
+    assert database.count_records(sensor_readings) == 9
 
 
 def test_run_reallocate(store, database, raw_metrics, raw_metrics_reallocate_policy):
@@ -230,6 +242,9 @@ def test_run_reallocate(store, database, raw_metrics, raw_metrics_reallocate_pol
     database_url = store.database.dburi
     runner = CliRunner()
 
+    # Check number of records in database.
+    assert database.count_records(raw_metrics) == 6
+
     # Invoke data retention through CLI interface.
     result = runner.invoke(
         cli,
@@ -238,11 +253,11 @@ def test_run_reallocate(store, database, raw_metrics, raw_metrics_reallocate_pol
     )
     assert result.exit_code == 0
 
-    # Verify that records have been deleted.
+    # Check number of records in database.
     # FIXME: Currently, the test for this strategy apparently does not remove any records.
     #        The reason is because the scenario can't easily be simulated on a single-node
     #        cluster. The suite would need to orchestrate at least two nodes.
-    assert database.count_records(f'"{TESTDRIVE_DATA_SCHEMA}"."raw_metrics"') == 6
+    assert database.count_records(raw_metrics) == 6
 
 
 def test_run_snapshot(caplog, store, database, sensor_readings, sensor_readings_snapshot_policy):


### PR DESCRIPTION
- Tests: Stronger linting.
- Tests: Stronger assertions about number of records in database.
- CI: Use `TC_KEEPALIVE` to not tear down Testcontainers.
  I've always used it in my sandbox, but missed to bring it to CI.
  It significantly reduces overall runtime, because the CrateDB container takes a few seconds to boot each time.
- Update backlog.
