### PR TITLE
Tests: Add integration tests for the "SNAPSHOT" strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,19 @@ or on a supported object storage backend. CrateDB is able to use buckets on S3-c
 storage backends, or on Azure blob storage, using the `CREATE REPOSITORY ... TYPE = 
 s3|azure|fs` SQL statement.
 
+```sql
+CREATE REPOSITORY
+    export_cold
+TYPE
+    s3
+WITH (
+    protocol   = 'https',
+    endpoint   = 's3-store.example.org:443',
+    access_key = '<USERNAME>',
+    secret_key = '<PASSWORD>',
+    bucket     = 'cratedb-cold-storage'
+);
+```
 ```shell
 cratedb-retention create-policy --strategy=snapshot \
   --table-schema=doc --table-name=sensor_readings \

--- a/cratedb_retention/util/database.py
+++ b/cratedb_retention/util/database.py
@@ -73,6 +73,31 @@ class DatabaseAdapter:
             if "RepositoryUnknownException" not in str(ex):
                 raise
 
+    def ensure_repository_fs(
+        self,
+        name: str,
+        typename: str,
+        location: str,
+        drop: bool = False,
+    ):
+        """
+        Make sure the repository exists, and optionally drop it upfront.
+        """
+        if drop:
+            self.drop_repository(name)
+
+        # TODO: CREATE REPOSITORY IF NOT EXISTS
+        sql = f"""
+            CREATE REPOSITORY
+                {name}
+            TYPE
+                {typename}
+            WITH (
+                location   = '{location}'
+            );
+        """
+        self.run_sql(sql)
+
     def ensure_repository_s3(
         self,
         name: str,

--- a/cratedb_retention/util/database.py
+++ b/cratedb_retention/util/database.py
@@ -106,6 +106,39 @@ class DatabaseAdapter:
         """
         self.run_sql(sql)
 
+    def ensure_repository_az(
+        self,
+        name: str,
+        typename: str,
+        protocol: str,
+        endpoint: str,
+        account: str,
+        key: str,
+        container: str,
+        drop: bool = False,
+    ):
+        """
+        Make sure the repository exists, and optionally drop it upfront.
+        """
+        if drop:
+            self.drop_repository(name)
+
+        # TODO: CREATE REPOSITORY IF NOT EXISTS
+        sql = f"""
+            CREATE REPOSITORY
+                {name}
+            TYPE
+                {typename}
+            WITH (
+                protocol   = '{protocol}',
+                endpoint   = '{endpoint}',
+                account    = '{account}',
+                key        = '{key}',
+                container  = '{container}'
+            );
+        """
+        self.run_sql(sql)
+
 
 def sa_is_empty(thing):
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,7 @@ test = [
   "pytest-cov<5",
   "pytest-mock<4",
   "testcontainers<4",
+  "testcontainers-azurite==0.0.1rc1",
   "testcontainers-minio==0.0.1rc1",
 ]
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,8 @@ test = [
   "pytest<8",
   "pytest-cov<5",
   "pytest-mock<4",
-  "testcontainers",
+  "testcontainers<4",
+  "testcontainers-minio==0.0.1rc1",
 ]
 [project.urls]
 changelog = "https://github.com/crate-workbench/cratedb-retention/blob/main/CHANGES.rst"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from cratedb_retention.setup.schema import setup_schema
 from cratedb_retention.store import RetentionPolicyStore
 from cratedb_retention.util.common import setup_logging
 from cratedb_retention.util.database import DatabaseAdapter, run_sql
+from tests.testcontainers.azurite import ExtendedAzuriteContainer
 from tests.testcontainers.cratedb import CrateDBContainer
 from tests.testcontainers.minio import ExtendedMinioContainer
 
@@ -81,6 +82,22 @@ def minio():
     """
     with ExtendedMinioContainer() as minio:
         yield minio
+
+
+@pytest.fixture(scope="session")
+def azurite():
+    """
+    For testing the "SNAPSHOT" strategy against a Microsoft Azure Blob Storage object storage API,
+    provide an Azurite service to the test suite.
+
+    - https://en.wikipedia.org/wiki/Object_storage
+    - https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azurite
+    - https://learn.microsoft.com/en-us/azure/storage/blobs/use-azurite-to-run-automated-tests
+    - https://github.com/azure/azurite
+    - https://crate.io/docs/crate/reference/en/latest/sql/statements/create-repository.html
+    """
+    with ExtendedAzuriteContainer() as azurite:
+        yield azurite
 
 
 @pytest.fixture()

--- a/tests/testcontainers/azurite.py
+++ b/tests/testcontainers/azurite.py
@@ -1,0 +1,74 @@
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+import typing as t
+
+from azure.storage.blob import BlobServiceClient, ContainerClient
+from testcontainers.azurite import AzuriteContainer
+
+from tests.testcontainers.util import ExtendedDockerContainer
+
+
+class ExtendedAzuriteContainer(ExtendedDockerContainer, AzuriteContainer):
+    """
+    An extended Testcontainer for Azurite, emulating Microsoft Azure Blob Storage.
+
+    Features
+    - Use the `latest` OCI image from https://quay.io/.
+    - Provide convenience methods for getting the Docker-internal endpoint address.
+
+    References
+    - https://en.wikipedia.org/wiki/Object_storage
+    - https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azurite
+    - https://learn.microsoft.com/en-us/azure/storage/blobs/use-azurite-to-run-automated-tests
+    - https://github.com/azure/azurite
+    """
+
+    def get_real_host_address(self) -> str:
+        """
+        Provide Docker-internal full endpoint address `<host>:<port>` of the service.
+        For example, `172.17.0.4:10000`.
+        """
+        return f"{self.get_real_host_ip()}:{self._BLOB_SERVICE_PORT}"
+
+    def get_container_endpoint(self, container_name: str):
+        container = self.get_container(container_name)
+        hostname = self.get_real_host_address()
+        return container._format_url(hostname=hostname)
+
+    def get_blob_service_client(self) -> BlobServiceClient:
+        """
+        Client handle to communicate with the service.
+        """
+        connection_string = self.get_connection_string()
+        return BlobServiceClient.from_connection_string(connection_string, api_version="2019-12-12")
+
+    def create_container(self, container_name: str) -> ContainerClient:
+        """
+        Create a blob container, and return container client.
+        """
+        blob_service_client = self.get_blob_service_client()
+        return blob_service_client.create_container(container_name)
+
+    def get_container(self, container_name: str) -> ContainerClient:
+        """
+        Get a blob container, and return container client.
+        """
+        blob_service_client = self.get_blob_service_client()
+        return blob_service_client.get_container_client(container_name)
+
+    def list_blob_names(self, container_name: str) -> t.List[str]:
+        """
+        Return list of blob names within given container.
+        """
+        container = self.get_container(container_name)
+        return list(container.list_blob_names())

--- a/tests/testcontainers/cratedb.py
+++ b/tests/testcontainers/cratedb.py
@@ -68,6 +68,7 @@ class CrateDBContainer(DbContainer):
         self._command = "-Cdiscovery.type=single-node -Ccluster.routing.allocation.disk.threshold_enabled=false"
         # TODO: Generalize by obtaining more_opts from caller.
         self._command += " -Cnode.attr.storage=hot"
+        self._command += " -Cpath.repo=/tmp/snapshots"
 
         self.CRATEDB_USER = user or self.CRATEDB_USER
         self.CRATEDB_PASSWORD = password or self.CRATEDB_PASSWORD

--- a/tests/testcontainers/minio.py
+++ b/tests/testcontainers/minio.py
@@ -1,0 +1,46 @@
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+import typing as t
+
+from testcontainers.minio import MinioContainer
+
+from tests.testcontainers.util import ExtendedDockerContainer
+
+
+class ExtendedMinioContainer(ExtendedDockerContainer, MinioContainer):
+    """
+    An extended Testcontainer for MinIO, emulating AWS S3.
+
+    Features
+    - Use the `latest` OCI image from https://quay.io/.
+    - Provide convenience methods for getting the Docker-internal endpoint address.
+
+    References
+    - https://en.wikipedia.org/wiki/Object_storage
+    - https://en.wikipedia.org/wiki/Amazon_S3
+    - https://github.com/minio/minio
+    """
+
+    def __init__(self, *args, **kwargs):
+        # Use most recent stable release of MinIO.
+        image = "quay.io/minio/minio:latest"
+        kwargs.setdefault("image", image)
+
+        super().__init__(*args, **kwargs)
+
+    def list_object_names(self, bucket_name: str) -> t.List[str]:
+        """
+        Return list of object names within given bucket.
+        """
+        objects = self.get_client().list_objects(bucket_name=bucket_name)
+        return [obj.object_name for obj in objects]

--- a/tests/testcontainers/util.py
+++ b/tests/testcontainers/util.py
@@ -1,0 +1,36 @@
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+from testcontainers.core.container import DockerContainer
+
+
+class ExtendedDockerContainer(DockerContainer):
+    """
+    An extended Testcontainer.
+
+    - Provide convenience methods for getting the Docker-internal endpoint address.
+      TODO: Maybe rename to `get_bridge_host_*`?
+    """
+
+    def get_real_host_ip(self) -> str:
+        """
+        To let containers talk to each other, explicitly provide the real IP address
+        of the container. In corresponding jargon, it appears to be the "bridge IP".
+        """
+        return self.get_docker_client().bridge_ip(self._container.id)
+
+    def get_real_host_address(self) -> str:
+        """
+        Provide Docker-internal full endpoint address `<host>:<port>` of the service.
+        For example, `172.17.0.4:9000`.
+        """
+        return f"{self.get_real_host_ip()}:{self.port_to_expose}"


### PR DESCRIPTION
## Introduction

The "SNAPSHOT" strategy has not been tested thoroughly yet.

```diff
- # FIXME: This currently can not be tested, because it needs a snapshot repository.
- # TODO: Provide an embedded MinIO S3 instance to the test suite.
```

## Improvement

This patch provides additional infrastructure to the test suite, and validates the full roundtrip by creating a snapshot repository, running the snapshot procedure, and verifying that data has moved correctly.

## Details

For verifying different repository types, different helper services and APIs are used.

- Filesystem: Uses the [Python Docker API](https://pypi.org/project/docker/) to introspect the filesystem of the OCI container where CrateDB is running.
- AWS S3: Uses [MinIO](https://github.com/minio/minio) to provide a compatible service.
- Azure Blob Storage: Uses [Azurite](https://github.com/azure/azurite) to provide a compatible service.
  _Does not work yet, because CrateDB does not support custom endpoints for Azure Blob Storage._
