### PR TITLE
Core: When running jobs without cutoff date, use `today()` as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ cratedb-retention create-policy --strategy=delete \
 This retention policy implements the following directive.
 
 > **Delete** all data from the `"doc"."raw_metrics"` table, on partitions defined by
-> the column `ts_day`, which is older than **1** day at the given cut-off date.
+> the column `ts_day`, which is older than **1** day at the given cutoff date when
+> running the retention job.
 
 [implementation](cratedb_retention/strategy/delete.py) | [tutorial](https://community.crate.io/t/cratedb-and-apache-airflow-implementation-of-data-retention-policy/913) 
 
@@ -114,7 +115,7 @@ cratedb-retention create-policy --strategy=reallocate \
 This retention policy implements the following directive.
 
 > **Reallocate** data from the `"doc"."raw_metrics"` table, on partitions defined by
-> the column `ts_day`, which is older than **60** days at the given cut-off date, to
+> the column `ts_day`, which is older than **60** days at the given cutoff date, to
 > nodes tagged with the `storage=warm` attribute.
 
 [implementation](cratedb_retention/strategy/reallocate.py) | [tutorial](https://community.crate.io/t/cratedb-and-apache-airflow-building-a-hot-cold-storage-data-retention-policy/934)
@@ -155,7 +156,7 @@ cratedb-retention create-policy --strategy=snapshot \
 This retention policy implements the following directive.
 
 > Run a **snapshot** on the data within the `"doc"."sensor_readings"` table, on partitions
-> defined by the column `time_month`, which is older than **365** days at the given cut-off
+> defined by the column `time_month`, which is older than **365** days at the given cutoff
 > date, to a previously created repository called `export_cold`. Delete the corresponding
 > data afterwards.
 
@@ -277,7 +278,7 @@ tag values, and combine them using `OR`. Running retention jobs for multiple tag
 needs multiple invocations.
 
 ```shell
-cratedb-retention run --cutoff-day=2023-06-27 --strategy=delete --tags=foo,bar "${CRATEDB_URI}"
+cratedb-retention run --strategy=delete --tags=foo,bar "${CRATEDB_URI}"
 ```
 
 
@@ -368,14 +369,20 @@ cratedb-retention create-policy --strategy=delete \
   "${CRATEDB_URI}"
 ```
 
-Invoke the data retention job, using a specific cut-off date.
+Invoke the data retention job, expiring all data older than one day.
+```shell
+cratedb-retention run --strategy=delete "${CRATEDB_URI}"
+```
+
+Invoke the data retention job, expiring all data older than one day before
+a specific cutoff date.
 ```shell
 cratedb-retention run --cutoff-day=2023-06-27 --strategy=delete "${CRATEDB_URI}"
 ```
 
 Simulate the data retention job, display SQL statements only.
 ```shell
-cratedb-retention run --dry-run --cutoff-day=2023-06-27 --strategy=delete "${CRATEDB_URI}"
+cratedb-retention run --dry-run --strategy=delete "${CRATEDB_URI}"
 ```
 
 #### Podman or Docker
@@ -421,10 +428,10 @@ cratedb-retention create-policy --strategy=delete \
   "${CRATEDB_URI}"
 ```
 
-Invoke the data retention job, using a specific cut-off date.
+Invoke the data retention job.
 ```shell
 docker run --rm -i --network=host "${OCI_IMAGE}" \
-cratedb-retention run --cutoff-day=2023-06-27 --strategy=delete "${CRATEDB_URI}"
+cratedb-retention run --strategy=delete "${CRATEDB_URI}"
 ```
 
 
@@ -471,7 +478,6 @@ identifier = store.create(policy, ignore="DuplicateKeyException")
 settings = JobSettings(
     database=DatabaseAddress.from_string(DBURI),
     strategy=RetentionStrategy.DELETE,
-    cutoff_day="2023-06-27",
 )
 
 job = RetentionJob(settings=settings)

--- a/cratedb_retention/cli.py
+++ b/cratedb_retention/cli.py
@@ -114,6 +114,13 @@ schema_option: t.Any = click.option(
     help="Select schema where extension tables are created",
 )
 
+cutoff_date_option: t.Any = click.option(
+    "--cutoff-day",
+    type=str,
+    required=False,
+    help="Select cutoff date. Retire all data older than »cutoff date« minus "
+    "»data retention duration«. The default value is 'today()'.",
+)
 strategy_option: t.Any = click.option(
     "--strategy",
     type=str,
@@ -280,7 +287,7 @@ def delete_policy(ctx: click.Context, dburi: str, schema: str, identifier: str, 
 @click.argument("dburi", envvar="CRATEDB_URI")
 @dryrun_option
 @schema_option
-@click.option("--cutoff-day", type=str, required=True, help="Select cut-off date parameter")
+@cutoff_date_option
 @strategy_option
 @tags_option
 @click.pass_context

--- a/cratedb_retention/core.py
+++ b/cratedb_retention/core.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2021-2023, Crate.io Inc.
 # Distributed under the terms of the AGPLv3 license, see LICENSE.
+import datetime
 import logging
 import typing as t
 
@@ -25,6 +26,12 @@ class RetentionJob:
     """
 
     def __init__(self, settings: JobSettings):
+        # When no cutoff date is obtained from the caller, use `today()` as default value.
+        if settings.cutoff_day is None:
+            today = datetime.date.today().isoformat()
+            logger.info(f"No cutoff date selected, will use today(): {today}")
+            settings.cutoff_day = today
+
         # Runtime context settings.
         self.settings = settings
 
@@ -39,7 +46,7 @@ class RetentionJob:
             f"Connecting to database {self.settings.database.safe}, " f"table {self.settings.policy_table.fullname}"
         )
 
-        msg = f"Starting data retention using '{self.settings.strategy}', cut-off day '{self.settings.cutoff_day}'"
+        msg = f"Starting data retention using '{self.settings.strategy}', cutoff day '{self.settings.cutoff_day}'"
         if self.settings.tags:
             msg += f", and tags '{self.settings.tags}'"
         logger.info(msg)

--- a/examples/retire_cutoff.py
+++ b/examples/retire_cutoff.py
@@ -7,6 +7,10 @@ About
 Example program demonstrating how to create retention policy records,
 and invoke retention tasks.
 
+Specifically, this example demonstrates how to use a given cutoff date
+when invoking the data retention job, in order to retire all data before
+that date and the configured retention duration time.
+
 It initializes the data retention and expiry subsystem, and creates
 a data retention policy. After that, it invokes the corresponding
 data retention job.
@@ -23,10 +27,10 @@ Synopsis
     pip install cratedb-retention
 
     # General.
-    python examples/full.py crate://<USERNAME>:<PASSWORD>@<HOSTNAME>:4200?ssl=true
+    python examples/retire_cutoff.py crate://<USERNAME>:<PASSWORD>@<HOSTNAME>:4200?ssl=true
 
     # Default.
-    python examples/full.py crate://localhost:4200
+    python examples/retire_cutoff.py crate://localhost:4200
 
 """
 import logging
@@ -42,9 +46,9 @@ from cratedb_retention.util.database import DatabaseAdapter
 logger = logging.getLogger(__name__)
 
 
-class FullExample:
+class RetireCutoffExample:
     """
-    An example program demonstrating retention policy editing.
+    An example program demonstrating data retention with given cutoff date.
     """
 
     def __init__(self, dburi):
@@ -147,7 +151,7 @@ def main(dburi: str):
 
     # Set up all the jazz.
     logger.info("Provisioning database")
-    example = FullExample(dburi=dburi)
+    example = RetireCutoffExample(dburi=dburi)
     example.cleanup()
     example.setup()
     example.setup_data()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2023, Crate.io Inc.
 # Distributed under the terms of the AGPLv3 license, see LICENSE.
+import datetime
+
 import pytest
 
 from cratedb_retention.core import RetentionJob
@@ -45,7 +47,7 @@ def test_data_table_not_found(caplog, store, settings):
 
 def test_no_cutoff_date_given(caplog, store, settings):
     """
-    Verify the engine reports correctly when invoked without cutoff date.
+    Verify the engine uses default=today() when invoked without cutoff date.
     """
     # Add a retention policy.
     policy = RetentionPolicy(
@@ -63,9 +65,10 @@ def test_no_cutoff_date_given(caplog, store, settings):
     # Invoke the data retention job.
     settings.strategy = RetentionStrategy.DELETE
     job = RetentionJob(settings=settings)
-    with pytest.raises(ValueError) as ex:
-        job.start()
-    assert ex.match("Unable to operate without cutoff date")
+    job.start()
+
+    today = datetime.date.today().isoformat()
+    assert f"No cutoff date selected, will use today(): {today}" in caplog.messages
 
 
 def test_no_data_to_be_retired(caplog, store, settings):

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -2,11 +2,11 @@
 # Distributed under the terms of the AGPLv3 license, see LICENSE.
 
 
-def test_example_full(store):
+def test_example_retire_cutoff(store):
     """
     Verify that the program `examples/basic.py` works.
     """
-    from examples.full import main
+    from examples.retire_cutoff import main
 
     main(dburi=store.database.dburi)
 


### PR DESCRIPTION
## About

I am extremely wary about using default parameters for the engine parts of such a powerful application, but in this particular case, I think it is fine to assume `today()` as default parameter for the `cutoff_day` parameter obtained from the caller.
