### PR TITLE
Fix: `DROP REPOSITORY` now returns `RepositoryMissingException`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,10 @@
 
 - Use full-qualified table names everywhere.
 
+- Fix: Compensate for `DROP REPOSITORY` now returning `RepositoryMissingException`
+  when the repository does not exist. With previous versions of CrateDB, it was
+  `RepositoryUnknownException`.
+
 ## 2023/06/27 0.0.0
 
 - Import "data retention" implementation from <https://github.com/crate/crate-airflow-tutorial>.

--- a/cratedb_retention/util/data.py
+++ b/cratedb_retention/util/data.py
@@ -7,3 +7,11 @@ def jd(data: t.Any):
     Pretty-print JSON with indentation.
     """
     print(json.dumps(data, indent=2))  # noqa: T201
+
+
+def str_contains(haystack, *needles):
+    """
+    Whether haystack contains any of the provided needles.
+    """
+    haystack = str(haystack)
+    return any(needle in haystack for needle in needles)

--- a/cratedb_retention/util/database.py
+++ b/cratedb_retention/util/database.py
@@ -4,6 +4,8 @@ import sqlalchemy as sa
 from sqlalchemy.exc import ProgrammingError
 from sqlalchemy.sql.elements import AsBoolean
 
+from cratedb_retention.util.data import str_contains
+
 
 def run_sql(dburi: str, sql: str, records: bool = False):
     return DatabaseAdapter(dburi=dburi).run_sql(sql=sql, records=records)
@@ -70,7 +72,7 @@ class DatabaseAdapter:
             sql = f"DROP REPOSITORY {name};"
             self.run_sql(sql)
         except ProgrammingError as ex:
-            if "RepositoryUnknownException" not in str(ex):
+            if not str_contains(ex, "RepositoryUnknownException", "RepositoryMissingException"):
                 raise
 
     def ensure_repository_fs(


### PR DESCRIPTION
## Problem

All the PRs submitted by Dependabot failed.

## Root cause

When a snapshot repository does not exist, `DROP REPOSITORY` now returns `RepositoryMissingException`.
With previous versions of CrateDB, it was `RepositoryUnknownException`. /cc @SStorm, @faymarie

## Solution

This patch will make the code accept both variants.

## Details

It first happened on GH-38, submitted by Dependabot on Sep 1, 2023.
